### PR TITLE
fix(openapi): corret path events/current

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -86,7 +86,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/events/current/": {
+        "/api/v1/events/current": {
             "get": {
                 "description": "Get current prescaling Event",
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -77,7 +77,7 @@
                 }
             }
         },
-        "/api/v1/events/current/": {
+        "/api/v1/events/current": {
             "get": {
                 "description": "Get current prescaling Event",
                 "consumes": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -199,7 +199,7 @@ paths:
       summary: Update a prescaling Event by name
       tags:
       - prescalingevent
-  /api/v1/events/current/:
+  /api/v1/events/current:
     get:
       consumes:
       - application/json


### PR DESCRIPTION
## Describe

When we use swagger we have a 404 error with endpoint /current


## How

Correct path in line with the go code.