### PR TITLE
refacto: rename metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ spec:
   metrics:
   - type: External
     external:
-      metricName: "prescale_metric"
+      metricName: "prescaling_metric"
       metricSelector:
           matchLabels:
             deployment: "{{ .Release.Name }}"
@@ -70,12 +70,12 @@ Here is a configuration example using the prometheus adapter to supply the metri
 ```
   - "metricsQuery": "avg(<<.Series>>{<<.LabelMatchers>>})"
     "name":
-      "as": "prescale_metric"
+      "as": "prescaling_metric"
     "resources":
       "overrides":
         "namespace":
           "resource": "namespace"
-    "seriesQuery": "prescale_metric"
+    "seriesQuery": "prescaling_metric"
 ```
 
 ## Configure parameters 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -17,12 +17,12 @@ type prescalingCollector struct {
 func NewPrescalingCollector(p prescaling.IPrescaling) prometheus.Collector {
 	return &prescalingCollector{
 		prescaleMetrics: prometheus.NewDesc(
-			"prescale_metric",
+			"prescaling_metric",
 			"Number used for prescale application",
 			[]string{"project", "deployment", "namespace"},
 			nil,
 		), minMetrics: prometheus.NewDesc(
-			"min_replica",
+			"prescaling_min_replica",
 			"Number of pod desired for prescale",
 			[]string{"project", "deployment", "namespace"},
 			nil,


### PR DESCRIPTION
# Describe

We want to uniforme naming for metrics 

# How

prefix metrics with prescaling_ 