### PR TITLE
fix(golang): add mulitplier in min_replica

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -64,7 +64,7 @@ func (collector *prescalingCollector) addDataToMetrics(ch chan<- prometheus.Metr
 	eventInRangeTime := utils.InRangeTime(hpa.Start, hpa.End, collector.prescaling.GetEventService().GetClock().Now())
 	desiredScalingType := prescaling.DesiredScaling(eventInRangeTime, multiplier, hpa.Replica, hpa.CurrentReplicas)
 	prescaleMetric := prometheus.MustNewConstMetric(collector.prescaleMetrics, prometheus.GaugeValue, float64(desiredScalingType), hpa.Project, hpa.Deployment, hpa.Namespace)
-	minMetric := prometheus.MustNewConstMetric(collector.minMetrics, prometheus.GaugeValue, float64(hpa.Replica), hpa.Project, hpa.Deployment, hpa.Namespace)
+	minMetric := prometheus.MustNewConstMetric(collector.minMetrics, prometheus.GaugeValue, float64(hpa.Replica * multiplier), hpa.Project, hpa.Deployment, hpa.Namespace)
 	ch <- prescaleMetric
 	ch <- minMetric
 }


### PR DESCRIPTION
## Describe

prescaling_min_replica metric is not multiplied when an entent is created.

##How

Add mulitplier in value calcul