### PR TITLE
docs(swagger): add code 204 for delete

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -228,6 +228,9 @@ const docTemplate = `{
                     "200": {
                         "description": "OK"
                     },
+                    "204": {
+                        "description": "No Content"
+                    },
                     "400": {
                         "description": "Bad Request",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -219,6 +219,9 @@
                     "200": {
                         "description": "OK"
                     },
+                    "204": {
+                        "description": "No Content"
+                    },
                     "400": {
                         "description": "Bad Request",
                         "schema": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -130,6 +130,9 @@ paths:
       responses:
         "200":
           description: OK
+      responses:
+        "204":
+          description: No Content
         "400":
           description: Bad Request
           schema:

--- a/swagger/doc.yaml
+++ b/swagger/doc.yaml
@@ -57,6 +57,8 @@ paths:
       responses:
         '200':
           description: 'Event has been deleted'
+        '204':
+          description: 'No content'
         '404':
           description: 'No event found'
           content:


### PR DESCRIPTION
## Describe

Today when we want delete an object which does not exist, api return a 204 but we don't have document this code return in swagger. 

## How

Add code 204 fro delete methode in swagger