### PR TITLE
fix(helm): indentation return into monitoring

### DIFF
--- a/helm/prescaling-exporter/templates/monitor.yaml
+++ b/helm/prescaling-exporter/templates/monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.monitor.enabled -}}
+{{- if .Values.prometheus.monitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -22,9 +22,9 @@ spec:
       relabelings:
       {{ toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
       {{- end }}
-{{- end -}}
+{{- end }}
 
-{{- if .Values.victoriametrics.monitor.enabled -}}
+{{- if .Values.victoriametrics.monitor.enabled }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
@@ -47,4 +47,4 @@ spec:
   selector:
     matchLabels:
       {{- include "prescaling-exporter.selectorLabels" . | nindent 8 }}
-{{- end -}}
+{{- end }}

--- a/helm/prescaling-exporter/templates/monitor.yaml
+++ b/helm/prescaling-exporter/templates/monitor.yaml
@@ -24,6 +24,8 @@ spec:
       {{- end }}
 {{- end }}
 
+--- 
+
 {{- if .Values.victoriametrics.monitor.enabled }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape


### PR DESCRIPTION
## Why : 
There was an error in the template so we cant enable the prometheus metric. Due to the `-` new lines were deleted. 

## How
Removing the `-` at the end of the line

