### PR TITLE
fix(helm): indentation issue with addtionalLabels in monitor

### DIFF
--- a/helm/prescaling-exporter/templates/monitor.yaml
+++ b/helm/prescaling-exporter/templates/monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "prescaling-exporter.labels" . | nindent 4 }}
     {{- if .Values.prometheus.monitor.additionalLabels }}
-    {{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
+    {{- toYaml .Values.prometheus.monitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   selector:
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       {{- if .Values.prometheus.monitor.relabelings }}
       relabelings:
-      {{ toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+      {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
       {{- end }}
 {{- end }}
 
@@ -34,7 +34,7 @@ metadata:
   labels:
     {{- include "prescaling-exporter.labels" . | nindent 4 }}
     {{- if .Values.victoriametrics.monitor.additionalLabels }}
-    {{ toYaml .Values.victoriametrics.monitor.additionalLabels | indent 4 }}
+    {{- toYaml .Values.victoriametrics.monitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
@@ -43,7 +43,7 @@ spec:
       scrapeTimeout: {{ .Values.victoriametrics.monitor.scrapeTimeout }}
       {{- if .Values.victoriametrics.monitor.relabelings }}
       relabelConfigs: 
-      {{ toYaml .Values.victoriametrics.monitor.relabelings | nindent 8 }}
+      {{- toYaml .Values.victoriametrics.monitor.relabelings | nindent 8 }}
       {{- end }}
   jobLabel: {{ template "prescaling-exporter.fullname" . }}
   selector:


### PR DESCRIPTION
I am struggling with indentation issue with `additionalLabels` from the monitor section. Helm failed to generate the charts 

When I had values : 
```
victoriametrics:
	monitor:
		additionalLabels:
			 mylabel: value
```
## Actual result 
```
apiVersion: operator.victoriametrics.com/v1beta1                                                                                                                                                                                                                                        
  kind: VMServiceScrape                                                                                                                                                                                                                                                                   
  metadata:                                                                                                                                                                                                                                                                               
    name: prescaling-exporter                                                                                                                                                                                                                                                             
    labels:                                                                                                                                                                                                                                                                               
      helm.sh/chart: prescaling-exporter-0.7.1                                                                                                                                                                                                                                            
      app.kubernetes.io/name: prescaling-exporter                                                                                                                                                                                                                                         
      app.kubernetes.io/instance: prescaling-exporter                                                                                                                                                                                                                                     
      app.kubernetes.io/version: "0.7.1"                                                                                                                                                                                                                                                  
      app.kubernetes.io/managed-by: Helm                                                                                                                                                                                                                                                  
           mylabel: value                                                                                                                                                                                                                                                                    
  spec:  
```

## Solution 
trim the custom labels. 
