### PR TITLE
feat(helm): add custom selector labels on ServiceMonitor

### DIFF
--- a/helm/prescaling-exporter/templates/monitor.yaml
+++ b/helm/prescaling-exporter/templates/monitor.yaml
@@ -13,6 +13,9 @@ spec:
     matchLabels:
       app: {{ template "prescaling-exporter.name" . }}
       release: {{ .Release.Name }}
+      {{- if .Values.prometheus.monitor.additionalSelectorLabels }}
+      {{- toYaml .Values.prometheus.monitor.additionalSelectorLabels | nindent 6 }}
+      {{- end }}
   endpoints:
     - port: metrics
       {{- if .Values.prometheus.monitor.scrapeTimeout }}
@@ -49,4 +52,7 @@ spec:
   selector:
     matchLabels:
       {{- include "prescaling-exporter.selectorLabels" . | nindent 8 }}
+      {{- if .Values.victoriametrics.monitor.additionalSelectorLabels }}
+      {{- toYaml .Values.victoriametrics.monitor.additionalSelectorLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/test-values.yml
+++ b/helm/test-values.yml
@@ -3,6 +3,7 @@ prometheus:
   monitor:
     enabled: false
     additionalLabels: {}
+    additionalSelectorLabels: {}
     relabelings:
       - action: replace
         regex: (.*)
@@ -27,6 +28,7 @@ victoriametrics:
   monitor: 
     enabled: true
     additionalLabels: {}
+    additionalSelectorLabels: {}
     relabelings:
       - action: replace
         regex: (.*)


### PR DESCRIPTION
Adding the possibility to add custom labels into the `selector.matchLabels` section from ServiceMonitor.