### PR TITLE
fix(helm): match service label with monitor selectorLabels

### DIFF
--- a/helm/prescaling-exporter/templates/monitor.yaml
+++ b/helm/prescaling-exporter/templates/monitor.yaml
@@ -13,8 +13,8 @@ spec:
     matchLabels:
       app: {{ template "prescaling-exporter.name" . }}
       release: {{ .Release.Name }}
-      {{- if .Values.prometheus.monitor.additionalSelectorLabels }}
-      {{- toYaml .Values.prometheus.monitor.additionalSelectorLabels | nindent 6 }}
+      {{- if .Values.service.additionalLabels }}
+      {{- toYaml .Values.service.additionalLabels | nindent 6 }}
       {{- end }}
   endpoints:
     - port: metrics
@@ -52,7 +52,7 @@ spec:
   selector:
     matchLabels:
       {{- include "prescaling-exporter.selectorLabels" . | nindent 8 }}
-      {{- if .Values.victoriametrics.monitor.additionalSelectorLabels }}
-      {{- toYaml .Values.victoriametrics.monitor.additionalSelectorLabels | nindent 8 }}
+      {{- if .Values.service.additionalLabels }}
+      {{- toYaml .Values.service.additionalLabels | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/helm/prescaling-exporter/templates/service.yaml
+++ b/helm/prescaling-exporter/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "prescaling-exporter.fullname" . }}
   labels:
     {{- include "prescaling-exporter.labels" . | nindent 4 }}
+    {{- if .Values.service.additionalLabels }}
+    {{- toYaml .Values.service.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/prescaling-exporter/values.yaml
+++ b/helm/prescaling-exporter/values.yaml
@@ -51,6 +51,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 9101
+  additionalLabels: {}
 
 ingress:
   enabled: false

--- a/helm/test-values.yml
+++ b/helm/test-values.yml
@@ -3,7 +3,6 @@ prometheus:
   monitor:
     enabled: false
     additionalLabels: {}
-    additionalSelectorLabels: {}
     relabelings:
       - action: replace
         regex: (.*)
@@ -28,7 +27,6 @@ victoriametrics:
   monitor: 
     enabled: true
     additionalLabels: {}
-    additionalSelectorLabels: {}
     relabelings:
       - action: replace
         regex: (.*)


### PR DESCRIPTION
Fix https://github.com/BedrockStreaming/prescaling-exporter/pull/116
Change the way we add additionalLabels to the service