### PR TITLE
feat: use timestamp format to RFC3339

### DIFF
--- a/helm/prescaling-exporter/templates/crds/prescalingevent.yaml
+++ b/helm/prescaling-exporter/templates/crds/prescalingevent.yaml
@@ -16,18 +16,25 @@ spec:
           properties:
             spec:
               type: object
-              required: ["date", "start_time", "end_time",  "multiplier", "description"]
+              required: ["date", "start_time", "end_time", "multiplier", "description"]
               properties:
                 date:
                   type: string
+                  example: "2022-05-25"
                 start_time:
                   type: string
+                  format: date-time
+                  example: "2022-05-25T20:00:00+02:00" # RFC3339 format, can be "20:00:00" too
                 end_time:
                   type: string
+                  format: date-time
+                  example: "2022-05-25T23:59:59+02:00" # RFC3339 format, can be "23:59:59" too
                 multiplier:
                   type: integer
+                  example: 2
                 description:
                   type: string
+                  example: "a good description"
   scope: Namespaced
   names:
     plural: prescalingevents

--- a/pkg/apis/prescaling.bedrock.tech/v1/types.go
+++ b/pkg/apis/prescaling.bedrock.tech/v1/types.go
@@ -13,11 +13,11 @@ type PrescalingEvent struct {
 }
 
 type PrescalingEventSpec struct {
-	Date        string `json:"date" example:"2022-05-25"`
-	StartTime   string `json:"start_time" example:"20:00:00"`
-	EndTime     string `json:"end_time" example:"23:59:59"`
-	Multiplier  int    `json:"multiplier" example:"2"`
-	Description string `json:"description" example:"a good description"`
+	Date        string `json:"date"`
+	StartTime   string `json:"start_time"`
+	EndTime     string `json:"end_time"`
+	Multiplier  int    `json:"multiplier"`
+	Description string `json:"description"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/prescaling/get_hpa_test.go
+++ b/pkg/prescaling/get_hpa_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/BedrockStreaming/prescaling-exporter/pkg/services"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/autoscaling/v2"
+	v2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclientk8s "k8s.io/client-go/kubernetes/fake"
 )
 
-var loc = time.Now().Local().Location()
+var loc = time.UTC
 
 func TestGetHpa(t *testing.T) {
 	fakeClock := clock.NewFakeClock(time.Date(2022, time.March, 2, 21, 0, 0, 0, loc))
@@ -77,8 +77,8 @@ func TestGetHpa(t *testing.T) {
 			Project:         "project-a",
 			Namespace:       "default",
 			Deployment:      "project-a",
-			Start:           time.Date(2022, time.March, 2, 20, 00, 0, 0, loc),
-			End:             time.Date(2022, time.March, 2, 23, 00, 0, 0, loc),
+			Start:           time.Date(2022, time.March, 2, 20, 00, 0, 0, time.UTC),
+			End:             time.Date(2022, time.March, 2, 23, 00, 0, 0, time.UTC),
 		},
 		{
 			Replica:         20,
@@ -86,8 +86,8 @@ func TestGetHpa(t *testing.T) {
 			Project:         "project-b",
 			Namespace:       "default",
 			Deployment:      "project-b",
-			Start:           time.Date(2022, time.March, 2, 18, 00, 0, 0, loc),
-			End:             time.Date(2022, time.March, 2, 23, 30, 0, 0, loc),
+			Start:           time.Date(2022, time.March, 2, 18, 00, 0, 0, time.UTC),
+			End:             time.Date(2022, time.March, 2, 23, 30, 0, 0, time.UTC),
 		},
 	}
 
@@ -199,8 +199,8 @@ func TestCheckAnnotationsKO(t *testing.T) {
 			name: "OK",
 			prescaling: Hpa{
 				Replica: 1,
-				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
-				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
+				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 			},
 		},
 		{
@@ -208,8 +208,8 @@ func TestCheckAnnotationsKO(t *testing.T) {
 			expected: "annotation replica min is misconfigured",
 			prescaling: Hpa{
 				Replica: 0,
-				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
-				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
+				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 			},
 		},
 		{
@@ -218,7 +218,7 @@ func TestCheckAnnotationsKO(t *testing.T) {
 			prescaling: Hpa{
 				Replica: 1,
 				Start:   time.Time{},
-				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 			},
 		},
 		{
@@ -226,7 +226,7 @@ func TestCheckAnnotationsKO(t *testing.T) {
 			expected: "annotation time start is misconfigured",
 			prescaling: Hpa{
 				Replica: 1,
-				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 				End:     time.Time{},
 			},
 		},
@@ -252,8 +252,8 @@ func TestCheckAnnotationsOK(t *testing.T) {
 			name: "OK - checkAnnotation return nil",
 			prescaling: Hpa{
 				Replica: 1,
-				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
-				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+				Start:   time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
+				End:     time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 			},
 		},
 	}

--- a/pkg/services/prescaling_event.go
+++ b/pkg/services/prescaling_event.go
@@ -134,7 +134,7 @@ func (e *PrescalingEventService) Update(prescalingevent *v1.PrescalingEvent) (*P
 		PrescalingEventSpec: v1.PrescalingEventSpec{
 			Date:        event.Spec.Date,
 			StartTime:   event.Spec.StartTime,
-			EndTime:     event.Spec.EndTime,
+			EndTime:     event.Spec.EndTime,	
 			Multiplier:  event.Spec.Multiplier,
 			Description: event.Spec.Description,
 		},
@@ -149,7 +149,7 @@ func (e *PrescalingEventService) Current() (*PrescalingEventOutput, error) {
 		return nil, err
 	}
 
-	filtered := filter(events.Items, func(event v1.PrescalingEvent) bool {
+		filtered := filter(events.Items, func(event v1.PrescalingEvent) bool {
 		date := e.clock.Now().Format("2006-01-02")
 
 		start, _ := utils.SetTime(event.Spec.StartTime, e.clock.Now())

--- a/pkg/services/prescaling_event_test.go
+++ b/pkg/services/prescaling_event_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestNewEventService(t *testing.T) {
 
-	fakeClock := testclock.NewFakeClock(time.Date(2022, time.March, 2, 21, 0, 0, 0, time.Now().Local().Location()))
+	fakeClock := testclock.NewFakeClock(time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC))
 	fakePrescalingEvents := &fake.FakePrescalingEvents{}
 
 	type args struct {
@@ -51,8 +51,7 @@ func TestNewEventService(t *testing.T) {
 }
 
 func TestPrescalingEventService_Current(t *testing.T) {
-	loc, _ := time.LoadLocation("Europe/Paris")
-	fakeClock := testclock.NewFakeClock(time.Date(2022, time.July, 2, 23, 0, 1, 0, loc))
+	fakeClock := testclock.NewFakeClock(time.Date(2022, time.July, 2, 23, 0, 1, 0, time.UTC))
 
 	cs := fakeclient.NewSimpleClientset(
 		&v1.PrescalingEvent{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,20 +2,40 @@ package utils
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 )
 
-func SetTime(str string, now time.Time) (time.Time, error) {
-	layOut := "15:04:05"
-	timeStamp, err := time.Parse(layOut, str)
-	if err != nil {
-		return time.Time{}, errors.New("the annotation time.start or time.end is malformed")
+// SetTime handles both RFC3339 format and legacy simple time format for backward compatibility
+// RFC3339: "2024-01-15T18:30:00+02:00" (preferred)
+// Legacy: "18:30:00" (assumes UTC)
+func SetTime(timeStr string, now time.Time) (time.Time, error) {
+	// Check if it's RFC3339 format (contains 'T' and timezone info)
+	if strings.Contains(timeStr, "T") && (strings.Contains(timeStr, "+") || strings.Contains(timeStr, "-") || strings.HasSuffix(timeStr, "Z")) {
+		// Parse RFC3339 format
+		parsedTime, err := time.Parse(time.RFC3339, timeStr)
+		if err != nil {
+			return time.Time{}, errors.New("the time string is malformed - expected RFC3339 format")
+		}
+
+		return time.Date(
+			now.Year(), now.Month(), now.Day(),
+			parsedTime.Hour(), parsedTime.Minute(), parsedTime.Second(),
+			0, parsedTime.Location()), nil
 	}
 
-	hour, min, sec := timeStamp.Clock()
-	dateTime := time.Date(now.Year(), now.Month(), now.Day(), hour, min, sec, 0, now.Location())
+	// Legacy format: simple time "HH:MM:SS"
+	parsedTime, err := time.Parse("15:04:05", timeStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("the time string is malformed - expected either RFC3339 format or HH:MM:SS format, got: %s", timeStr)
+	}
 
-	return dateTime, nil
+	// Use UTC for legacy format (backward compatibility)
+	return time.Date(
+		now.Year(), now.Month(), now.Day(),
+		parsedTime.Hour(), parsedTime.Minute(), parsedTime.Second(),
+		0, time.UTC), nil
 }
 
 func InRangeTime(dateStart time.Time, dateEnd time.Time, now time.Time) bool {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 // SetTime handles both RFC3339 format and legacy simple time format for backward compatibility
-// RFC3339: "2024-01-15T18:30:00+02:00" (preferred)
+// RFC3339: "2024-01-15T18:30:00+02:00" (preferred) - preserves original timezone
 // Legacy: "18:30:00" (assumes UTC)
 func SetTime(timeStr string, now time.Time) (time.Time, error) {
 	// Check if it's RFC3339 format (contains 'T' and timezone info)
@@ -31,7 +31,7 @@ func SetTime(timeStr string, now time.Time) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("the time string is malformed - expected either RFC3339 format or HH:MM:SS format, got: %s", timeStr)
 	}
 
-	// Use UTC for legacy format (backward compatibility)
+	// Use UTC for consistency when no timezone is specified
 	return time.Date(
 		now.Year(), now.Month(), now.Day(),
 		parsedTime.Hour(), parsedTime.Minute(), parsedTime.Second(),
@@ -39,6 +39,11 @@ func SetTime(timeStr string, now time.Time) (time.Time, error) {
 }
 
 func InRangeTime(dateStart time.Time, dateEnd time.Time, now time.Time) bool {
+	// Convert all times to UTC for consistent comparison
+	dateStart = dateStart.UTC()
+	dateEnd = dateEnd.UTC()
+	now = now.UTC()
+
 	if dateEnd.Before(dateStart) {
 		dateEnd = dateEnd.AddDate(0, 0, 1)
 	}
@@ -51,6 +56,10 @@ func InRangeTime(dateStart time.Time, dateEnd time.Time, now time.Time) bool {
 }
 
 func DaysBetweenDates(todayDate time.Time, eventDate time.Time) int {
+	// Convert both dates to UTC for accurate day calculation
+	todayDate = todayDate.UTC()
+	eventDate = eventDate.UTC()
+
 	if todayDate.After(eventDate) {
 		days := todayDate.Sub(eventDate).Hours() / 24
 		return int(days)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var loc = time.Now().Local().Location()
+// Utiliser UTC au lieu de Local pour éviter les problèmes de fuseaux horaires
+var loc = time.UTC
 
 func TestSetTime(t *testing.T) {
 
-	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, loc)
+	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC)
 
 	testCases := []struct {
 		name         string
@@ -21,12 +22,12 @@ func TestSetTime(t *testing.T) {
 		{
 			name:         "OK - Test 1",
 			dateStr:      "10:00:00",
-			dateExpected: time.Date(2022, time.March, 2, 10, 0, 0, 0, loc),
+			dateExpected: time.Date(2022, time.March, 2, 10, 0, 0, 0, time.UTC),
 		},
 		{
 			name:         "OK - Test 2",
 			dateStr:      "00:00:00",
-			dateExpected: time.Date(2022, time.March, 2, 0, 0, 0, 0, loc),
+			dateExpected: time.Date(2022, time.March, 2, 0, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -38,7 +39,7 @@ func TestSetTime(t *testing.T) {
 
 func TestSetTimeError(t *testing.T) {
 
-	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, loc)
+	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC)
 
 	testCases := []struct {
 		name    string
@@ -78,7 +79,7 @@ func TestSetTimeError(t *testing.T) {
 
 func TestInRangeTime(t *testing.T) {
 
-	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, loc)
+	faketime := time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC)
 
 	testCases := []struct {
 		expected  bool
@@ -88,38 +89,38 @@ func TestInRangeTime(t *testing.T) {
 	}{
 		{
 			name:      "OK - is inside the period ",
-			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 22, 0, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 22, 0, 0, 0, time.UTC),
 			expected:  true,
 		},
 		{
 			name:      "OK - dateStart and time.Now is Equal",
-			dateStart: time.Date(2022, time.March, 2, 21, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 22, 0, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 22, 0, 0, 0, time.UTC),
 			expected:  true,
 		},
 		{
 			name:      "OK - dateEnd and time.Now is Equal",
-			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 21, 0, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 21, 0, 0, 0, time.UTC),
 			expected:  true,
 		},
 		{
 			name:      "OK - dateEnd is after midnight",
-			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 0, 30, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 20, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 0, 30, 0, 0, time.UTC),
 			expected:  true,
 		},
 		{
 			name:      "KO - dateStart and dateEnd is inverted",
-			dateStart: time.Date(2022, time.March, 2, 22, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 0, 30, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 22, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 0, 30, 0, 0, time.UTC),
 			expected:  false,
 		},
 		{
 			name:      "KO - is outside the period",
-			dateStart: time.Date(2022, time.March, 2, 19, 0, 0, 0, loc),
-			dateEnd:   time.Date(2022, time.March, 2, 20, 30, 0, 0, loc),
+			dateStart: time.Date(2022, time.March, 2, 19, 0, 0, 0, time.UTC),
+			dateEnd:   time.Date(2022, time.March, 2, 20, 30, 0, 0, time.UTC),
 			expected:  false,
 		},
 	}
@@ -140,32 +141,32 @@ func TestDaysBetweenDates(t *testing.T) {
 	}{
 		{
 			name:      "OK - 10d8h",
-			today:     time.Date(2022, time.March, 13, 20, 0, 0, 0, loc),
-			eventDate: time.Date(2022, time.March, 2, 22, 0, 0, 0, loc),
+			today:     time.Date(2022, time.March, 13, 20, 0, 0, 0, time.UTC),
+			eventDate: time.Date(2022, time.March, 2, 22, 0, 0, 0, time.UTC),
 			expected:  10,
 		},
 		{
 			name:      "OK - 9d,8h",
-			today:     time.Date(2022, time.March, 12, 20, 0, 0, 0, loc),
-			eventDate: time.Date(2022, time.March, 2, 22, 0, 0, 0, loc),
+			today:     time.Date(2022, time.March, 12, 20, 0, 0, 0, time.UTC),
+			eventDate: time.Date(2022, time.March, 2, 22, 0, 0, 0, time.UTC),
 			expected:  9,
 		},
 		{
 			name:      "OK - 10d,1h",
-			today:     time.Date(2022, time.March, 12, 20, 0, 0, 0, loc),
-			eventDate: time.Date(2022, time.March, 2, 19, 0, 0, 0, loc),
+			today:     time.Date(2022, time.March, 12, 20, 0, 0, 0, time.UTC),
+			eventDate: time.Date(2022, time.March, 2, 19, 0, 0, 0, time.UTC),
 			expected:  10,
 		},
 		{
 			name:      "OK - 10d,1h",
-			today:     time.Date(2022, time.March, 2, 20, 0, 0, 0, loc),
-			eventDate: time.Date(2022, time.March, 12, 19, 0, 0, 0, loc),
+			today:     time.Date(2022, time.March, 2, 20, 0, 0, 0, time.UTC),
+			eventDate: time.Date(2022, time.March, 12, 19, 0, 0, 0, time.UTC),
 			expected:  0,
 		},
 		{
 			name:      "OK - 10d,1h",
-			today:     time.Date(2022, time.March, 2, 20, 0, 0, 0, loc),
-			eventDate: time.Date(2022, time.March, 2, 19, 0, 0, 0, loc),
+			today:     time.Date(2022, time.March, 2, 20, 0, 0, 0, time.UTC),
+			eventDate: time.Date(2022, time.March, 2, 19, 0, 0, 0, time.UTC),
 			expected:  0,
 		},
 	}


### PR DESCRIPTION
- Migrate PrescalingEventSpec to use RFC3339 format for StartTime/EndTime

- Update CRD schema with RFC3339 examples